### PR TITLE
Add 0% opacity to completely hide the toast

### DIFF
--- a/[MOD] smaller zen toast popup/preferences.json
+++ b/[MOD] smaller zen toast popup/preferences.json
@@ -7,6 +7,10 @@
     "defaultValue": "0.3",
     "options": [
       {
+        "label": "0%",
+        "value": "0"
+      },
+      {
         "label": "10%",
         "value": "0.1"
       },
@@ -40,6 +44,10 @@
     "defaultValue": "0.3",
     "options": [
       {
+        "label": "0%",
+        "value": "0"
+      },
+      {
         "label": "10%",
         "value": "0.1"
       },
@@ -72,6 +80,10 @@
     "placeholder": "Select text opacity",
     "defaultValue": "0.3",
     "options": [
+      {
+        "label": "0%",
+        "value": "0"
+      },
       {
         "label": "10%",
         "value": "0.1"


### PR DESCRIPTION
Personally, I've been trying to find a way to hide the toast but I couldn't. So, I thought about adding the 0% opacity to completely hide it.

Feel free to implement another way